### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -248,6 +248,7 @@ a {
   width: 37vh;
   padding: 1vw;
   background-color: #FFF;
+  display: flex;
 }
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.all
     
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,20 @@
+class Address < ApplicationRecord
+  belongs_to :user
+  has_many :purchases
+
+  with_options presence: true do
+    validates :zipcode
+    validates :city
+    validates :address_line
+    validates :phone_number
+    validates :user
+
+  end
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+    belongs_to_active_hash :prefecture
+    validates :prefecture, presence: true
+
+
+
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,20 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,12 @@
+class Purchase < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  belongs_to :address
+
+  with_options presence: true do
+    validates :user
+    validates :item
+    validates :address
+  end
+  
+end

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,0 +1,40 @@
+- if item.present?
+  -# <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+  %li.list
+    = link_to "#itemのidとひもづけて詳細ページに飛ぶパス" do
+      .item-img-content
+        = image_tag item.image, class: "item-img"
+        -# <%# 商品が売れていればsold outの表示 %>
+        - if Purchase.exists?(item_id: item.id)
+          .sold-out
+            %span Sold Out!!
+      .item-info
+        %h3.item-name
+          = item.name
+        .item-price
+          %span
+            = item.price
+            円
+            %br>/
+            (税込み)
+          .star-btn
+            = image_tag "star.png", class:"star-icon"
+            %span.star-count 0
+            -# <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+- else
+  -# <%# 商品がない場合のダミー %>
+  %li.list
+    = link_to '#' do
+      = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"
+      .item-info
+        %h3.item-name
+          商品を出品してね！
+        .item-price
+          %span
+            99999999円
+            %br>/
+            (税込み)
+          .star-btn
+            = image_tag "star.png", class:"star-icon"
+            %span.star-count 0
+

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -89,47 +89,8 @@
     %h2.title ピックアップカテゴリー
     = link_to '新規投稿商品', "#", class: "subtitle"
     %ul.item-lists
-      -# <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      %li.list
-        = link_to "#" do
-          .item-img-content
-            = image_tag "item-sample.png", class: "item-img"
-            -# <%# 商品が売れていればsold outの表示 %>
-            .sold-out
-              %span Sold Out!!
-          .item-info
-            %h3.item-name
-              = "商品名"
-            .item-price
-              %span
-                = "販売価格"
-                円
-                %br>/
-                (税込み)
-              .star-btn
-                = image_tag "star.png", class:"star-icon"
-                %span.star-count 0
-                -# <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      -# <%# 商品がない場合のダミー %>
-      -# <%# 商品がある場合は表示されないようにしましょう %>
-      %li.list
-        = link_to '#' do
-          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"
-          .item-info
-            %h3.item-name
-              商品を出品してね！
-            .item-price
-              %span
-                99999999円
-                %br>/
-                (税込み)
-              .star-btn
-                = image_tag "star.png", class:"star-icon"
-                %span.star-count 0
-      -# <%# //商品がある場合は表示されないようにしましょう %>
-      -# <%# //商品がない場合のダミー %>
-  
+      = render @items
+   
   -# <%# //商品一覧 %>
 .purchase-btn
   = link_to "出品する", new_item_path, class: "purchase-btn-text"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -2,9 +2,9 @@
 .item-show
   .item-box
     %h2.name
-      = "商品名"
+      = item.name
     .item-img-content
-      = image_tag "item-sample.png" ,class:"item-box-img"
+      = image_tag item.image ,class:"item-box-img"
       .sold-out
         %span Sold Out!!
     .item-price-box
@@ -12,11 +12,12 @@
         ¥ 999,999,999
       %span.item-postage
         (税込) 送料込み
-    = link_to '商品の編集', "#", method: :get, class: "item-red-btn"
+= link_to '商品の編集', "#", method: :get, class: "item-red-btn"
     %p.or-text or
     = link_to '削除', "#", method: :delete, class:'item-destroy'
     = link_to '購入画面に進む', "#" ,class:"item-red-btn"
-    .item-explain-box
+    
+.item-explain-box
       %span= "商品説明"
     %table.detail-table
       %tbody
@@ -65,4 +66,5 @@
   %a.another-item{:href => "#"}
     = "商品のカテゴリー名"
     をもっと見る
+  
 = render "shared/footer"

--- a/db/migrate/20200712093432_create_addresses.rb
+++ b/db/migrate/20200712093432_create_addresses.rb
@@ -1,0 +1,16 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.integer :zipcode,      null:false
+      t.integer :prefecture,   null:false
+      t.string :city,          null:false
+      t.string :address_line,  null:false
+      t.string :building
+      t.integer :phone_number, null:false
+      t.references :user,    null:false, foreign_key:true
+
+      t.timestamps
+    end
+ 
+  end
+end

--- a/db/migrate/20200712093500_create_purchases.rb
+++ b/db/migrate/20200712093500_create_purchases.rb
@@ -1,0 +1,11 @@
+class CreatePurchases < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchases do |t|
+      t.references :user,    null:false, foreign_key:true
+      t.references :item,    null:false, foreign_key:true
+      t.references :address, null:false, foreign_key:true
+      t.timestamps
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_11_082057) do
+ActiveRecord::Schema.define(version: 2020_07_12_093500) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,19 @@ ActiveRecord::Schema.define(version: 2020_07_11_082057) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "zipcode", null: false
+    t.integer "prefecture", null: false
+    t.string "city", null: false
+    t.string "address_line", null: false
+    t.string "building"
+    t.integer "phone_number", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
+
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "explanation", null: false
@@ -48,6 +61,17 @@ ActiveRecord::Schema.define(version: 2020_07_11_082057) do
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["name"], name: "index_items_on_name"
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.bigint "address_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["address_id"], name: "index_purchases_on_address_id"
+    t.index ["item_id"], name: "index_purchases_on_item_id"
+    t.index ["user_id"], name: "index_purchases_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -71,5 +95,9 @@ ActiveRecord::Schema.define(version: 2020_07_11_082057) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "users"
   add_foreign_key "items", "users"
+  add_foreign_key "purchases", "addresses"
+  add_foreign_key "purchases", "items"
+  add_foreign_key "purchases", "users"
 end


### PR DESCRIPTION
# What
* トップページの「新規投稿商品」に新規投稿された商品一覧が横並びで表示されるように実装した
* 1つの商品につき画像・商品名・価格の3つの情報が表示されている
* 売却済みの商品であれば「Sold Out」の文字が表示されるようにビューファイルに分岐を設定した
* 商品一覧はログアウトした状態でも閲覧できるようにしている

# Why
* まだ会員登録していないユーザーでも商品を見て新規登録しようと思ってもらうため

