### PR TITLE
コメント機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,4 @@ gem 'mini_magick'
 gem 'payjp'
 gem 'fog-aws'
 gem "aws-sdk-s3", require: false
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -361,6 +365,7 @@ DEPENDENCIES
   fog-aws
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,0 +1,39 @@
+$(function(){
+  function buildHTML(comment){
+    let html = 
+    `<div class="comments">
+      <div class="comment-date">
+        ${comment.created_at}
+      </div>
+      <div class="comment-nickname">
+        ${comment.nickname}
+      </div>
+      <div class="comment-content">
+        ${comment.text}
+      </div>
+    </div>`
+    return html;
+  }
+  $('#new-comment').on('submit', function(e){
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
+      $('.comment-index').append(html);
+      $('.comment-text').val('');
+      $('.comment-btn-box').prop('disabled', false);
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+});

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -1,5 +1,4 @@
 /* 商品の概要 */
-
 .item-show {
   background-color: #f8f8f8;
   width: 100vw;
@@ -147,6 +146,13 @@
   text-align: center;
 }
 
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
 .comment-text {
   width: 100%;
   height: 100px;
@@ -162,16 +168,21 @@
   text-align: left;
 }
 
-.comment-btn {
+.comment-btn-box {
   line-height: 48px;
   background-color: #3CCACE;
   border: 1px solid #3CCACE;
   color: #fff;
-  width: 50%;
+  width: 32%;
   min-width: 150px;
   font-size: 18px;
   border-radius: 100px;
   margin-bottom: 2vh;
+  display: flex;
+}
+
+.comment-btn {
+  margin-left: 10px;
 }
 
 .comment-flag {
@@ -180,7 +191,31 @@
 }
 
 .comment-flag-icon {
-  margin: 10px 5px 0 0;
+  margin: 10px 5px 0 10px;
+}
+
+.comments {
+  display: flex;
+  margin: 10px;
+  padding: 5px;
+  line-height: 16px;
+}
+
+.comment-date {
+  margin-right: 10px;
+  color: gray;
+  font-size: 5px;
+  
+}
+
+.comment-nickname {
+  margin-right: 5px;
+  color: #3CCACE;
+}
+
+.comment-nickname:after{
+  content: '：';
+  color: #3CCACE;
 }
 
 .links {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,15 @@
+class CommentsController < ApplicationController
+  def create
+    @comment = Comment.create(comment_params)
+    respond_to do |f|
+      f.html { redirect_to items_path(params[:item_id]) }
+      f.json
+    end
+    
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:text).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    
+    @comment = Comment.new
+    @comments = @item.comments.includes(:user)
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,11 @@
+class Comment < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+
+  with_options presence: true do
+    validates :text
+    validates :user
+    validates :item
+  end
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,10 +4,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
-    has_many :items
-    has_many :purchases
-    has_many :comments
-    has_many :addresses
+  has_many :items
+  has_many :purchases
+  has_many :comments
+  has_many :addresses
   
   with_options presence: true do
     validates :nickname, uniqueness: true

--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text @comment.text
+json.user_id @comment.user.id
+json.nickname @comment.user.nickname
+json.created_at @comment.created_at.strftime("%m/%d %H:%M")

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -1,0 +1,7 @@
+.comments
+  .comment-date
+    = comment.created_at.strftime("%m/%d %H:%M")
+  .comment-nickname
+    = comment.user.nickname
+  .comment-content
+    = comment.text

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -50,17 +50,28 @@
         = image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"
         %span 不適切な商品の通報
   .comment-box
-    %form
-      %textarea.comment-text
-      %p.comment-warn
-        相手のことを考え丁寧なコメントを心がけましょう。
-        %br/
-        不快な言葉遣いなどは利用制限や退会処分となることがあります。
-      %button.comment-btn{:type => "submit"}
-        = image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"
-        %span
-          コメントする
-          %span
+    - if Purchase.exists?(item_id: @item.id)
+      ※※※売り切れのためコメントできません※※※
+    - elsif user_signed_in?  
+      = form_with model: [@item, @comment], method: "POST", id: "new-comment", class: "comment-form",local: true do |f|
+        = f.text_area :text, class: "comment-text"
+        .comment-warn
+          相手のことを考え丁寧なコメントを心がけましょう。
+          %br/
+          不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        %button{type: "submit", class:'comment-btn-box'} 
+          = image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"
+          .comment-btn
+            コメントする
+
+    - else 
+      ※※※コメントの投稿には新規登録/ログインが必要です※※※
+    .comment-index
+      %h4 ＜コメント一覧＞
+      - if @comments
+        = render partial: 'comment', collection: @comments
+
+
   .links
     %a.change-item-btn{:href => "#"}
       ＜ 前の商品

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = csp_meta_tag
     
     = stylesheet_link_tag 'application', media: 'all'
-    = javascript_pack_tag 'application'
+    = javascript_include_tag 'application'
     %script{:src => "https://js.pay.jp/v1/", :type => "text/javascript"}
   %body
     = yield

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ module Furima26955
       g.test_framework false
     end
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
-
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root 'items#index'
   resources :items do
     resources :purchases, only:[:create, :new]
+    resources :comments, only: [:create]
   end
   
 end

--- a/db/migrate/20200722063840_create_comments.rb
+++ b/db/migrate/20200722063840_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.text :text
+      t.references :user
+      t.references :item
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_12_093500) do
+ActiveRecord::Schema.define(version: 2020_07_22_063840) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -46,6 +46,16 @@ ActiveRecord::Schema.define(version: 2020_07_12_093500) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_id"], name: "index_addresses_on_item_id"
     t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "text"
+    t.bigint "user_id"
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_comments_on_item_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# What
* 商品詳細ページの下部にあるフォームから、商品に関するコメントを出品者・購入者ともに投稿できるよう実装した
* コメント投稿はログイン済みのユーザーのみ可能
* コメント閲覧は未ログインユーザーも可能
* 売却済の商品にはコメント投稿ができないように設定
* コメントの投稿は非同期通信される

# Why
* 出品者が掲載していない情報を、購入を検討しているユーザーが確認できるようにするため
* 値下げ交渉/購入時期の交渉などユーザー同士がコミュニケーションを取った上で商品の売買ができるようにするため
* 利用規約に同意したユーザーのみがやり取りを行えるよう、コメント投稿はログイン済みのユーザーのみ可能にした。これにより、万が一トラブルが発生した場合も対応が容易になる。
* コメントにしかない商品情報を見て購入したいと考えるユーザーや、出品者・購入者のコミュニケーションを判断材料として会員登録を決めるユーザーも存在すると考えた。そのため、コメント閲覧は未ログインユーザーも可能な仕様にした。